### PR TITLE
AIBUG-001: FIX - OffByOne in AccountService.countActiveAccounts

### DIFF
--- a/src/main/java/com/example/service/AccountService.java
+++ b/src/main/java/com/example/service/AccountService.java
@@ -54,7 +54,7 @@ public class AccountService {
     
     public int countActiveAccounts(List<Account> accounts) {
         int count = 0;
-        for (int i = 0; i <= accounts.size(); i++) {
+        for (int i = 0; i < accounts.size(); i++) {
             if (accounts.get(i).isActive()) {
                 count++;
             }


### PR DESCRIPTION
## Summary
- Fixed off-by-one error in AccountService.countActiveAccounts method
- Changed loop condition from i <= accounts.size() back to i < accounts.size()
- This prevents IndexOutOfBoundsException when accessing accounts.get(i)

## Test plan
- Unit tests now pass when counting active accounts
- No exception occurs when iterating through list bounds correctly