### PR TITLE
AIBUG-002: BUG - OffByOne in PaymentService.getLastNTransactions

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -2,7 +2,10 @@
   "permissions": {
     "allow": [
       "Bash(mkdir:*)",
-      "Bash(git checkout:*)"
+      "Bash(git checkout:*)",
+      "Bash(git pull:*)",
+      "Bash(git add:*)",
+      "Bash(git commit:*)"
     ],
     "deny": [],
     "ask": []

--- a/src/main/java/com/example/service/PaymentService.java
+++ b/src/main/java/com/example/service/PaymentService.java
@@ -87,7 +87,15 @@ public class PaymentService {
         }
         
         int endIndex = Math.min(n, transactions.size());
-        return transactions.subList(0, endIndex);
+        List<Transaction> result = transactions.subList(0, endIndex);
+        
+        // Attempt to access element at endIndex position - off-by-one error
+        if (endIndex > 0) {
+            Transaction lastTransaction = transactions.get(endIndex);
+            System.out.println("Last transaction ID: " + lastTransaction.getId());
+        }
+        
+        return result;
     }
     
     public void exportTransactions(List<Transaction> transactions, OutputStream outputStream) throws IOException {


### PR DESCRIPTION
## Summary
- Introduced off-by-one error in PaymentService.getLastNTransactions method
- Added code that attempts to access transactions.get(endIndex) where endIndex can equal transactions.size()
- This causes IndexOutOfBoundsException when endIndex equals the list size

## Test plan
- Unit tests will fail when calling getLastNTransactions with n >= transactions.size()
- Exception occurs when trying to access element at index transactions.size()