### PR TITLE
AIBUG-003: BUG - NullPointer in PaymentService.processPayment

### DIFF
--- a/src/main/java/com/example/service/PaymentService.java
+++ b/src/main/java/com/example/service/PaymentService.java
@@ -74,8 +74,10 @@ public class PaymentService {
     
     public Receipt processPayment(Payment payment) {
         String note = "No note";
-        if (payment.getMetadata() != null) {
-            note = payment.getMetadata().getOrDefault("note", "No note");
+        // BUG: Removed null check for getMetadata() - will cause NullPointerException
+        note = payment.getMetadata().get("note");
+        if (note == null) {
+            note = "No note";
         }
         
         return new Receipt(payment.getId(), payment.getAmount(), note);


### PR DESCRIPTION
## Summary
- Introduced NullPointerException in PaymentService.processPayment method
- Removed null check for payment.getMetadata() before calling .get("note")
- This causes NPE when payment metadata is null

## Test plan
- Unit tests will fail when processPayment is called with payment that has null metadata
- Exception occurs when trying to call .get() on null metadata map