### PR TITLE
AIBUG-003: FIX - NullPointer in PaymentService.processPayment

### DIFF
--- a/src/main/java/com/example/service/PaymentService.java
+++ b/src/main/java/com/example/service/PaymentService.java
@@ -74,10 +74,12 @@ public class PaymentService {
     
     public Receipt processPayment(Payment payment) {
         String note = "No note";
-        // BUG: Removed null check for getMetadata() - will cause NullPointerException
-        note = payment.getMetadata().get("note");
-        if (note == null) {
-            note = "No note";
+        // FIX: Added null check for getMetadata() to prevent NullPointerException
+        if (payment.getMetadata() != null) {
+            String noteValue = payment.getMetadata().get("note");
+            if (noteValue != null) {
+                note = noteValue;
+            }
         }
         
         return new Receipt(payment.getId(), payment.getAmount(), note);


### PR DESCRIPTION
## Summary
- Fixed NullPointerException in PaymentService.processPayment method
- Added proper null checks for payment.getMetadata() before accessing map
- Prevents NPE when payment metadata is null

## Test plan
- Unit tests now pass when processPayment is called with null metadata
- No exception occurs when metadata is null or note value is null