### PR TITLE
AIBUG-004: BUG - NullPointer in AccountService.getPrimaryEmail

### DIFF
--- a/src/main/java/com/example/service/AccountService.java
+++ b/src/main/java/com/example/service/AccountService.java
@@ -63,10 +63,8 @@ public class AccountService {
     }
     
     public String getPrimaryEmail(User user) {
-        if (user.getEmails() != null && !user.getEmails().isEmpty()) {
-            return user.getEmails().get(0).getAddress();
-        }
-        return "no-email@example.com";
+        // BUG: Removed null and empty checks - will cause NPE or IndexOutOfBounds
+        return user.getEmails().get(0).getAddress();
     }
     
     public List<Account> findDuplicateAccounts(List<Account> accounts) {


### PR DESCRIPTION
## Summary
- Introduced NullPointerException in AccountService.getPrimaryEmail method
- Removed null and empty checks for user.getEmails()
- This causes NPE when emails list is null or IndexOutOfBoundsException when list is empty

## Test plan
- Unit tests will fail when getPrimaryEmail is called with user having null or empty emails list
- Exception occurs when trying to access .get(0) on null or empty list