### PR TITLE
AIBUG-004: FIX - NullPointer in AccountService.getPrimaryEmail

### DIFF
--- a/src/main/java/com/example/service/AccountService.java
+++ b/src/main/java/com/example/service/AccountService.java
@@ -63,8 +63,14 @@ public class AccountService {
     }
     
     public String getPrimaryEmail(User user) {
-        // BUG: Removed null and empty checks - will cause NPE or IndexOutOfBounds
-        return user.getEmails().get(0).getAddress();
+        // FIX: Added proper null and empty checks to prevent exceptions
+        if (user.getEmails() != null && !user.getEmails().isEmpty()) {
+            Email firstEmail = user.getEmails().get(0);
+            if (firstEmail != null) {
+                return firstEmail.getAddress();
+            }
+        }
+        return "no-email@example.com";
     }
     
     public List<Account> findDuplicateAccounts(List<Account> accounts) {


### PR DESCRIPTION
## Summary
- Fixed NullPointerException in AccountService.getPrimaryEmail method
- Added proper null and empty checks for user.getEmails() and first email element
- Prevents NPE when emails list is null and IndexOutOfBoundsException when list is empty

## Test plan
- Unit tests now pass when getPrimaryEmail is called with null or empty emails list
- Returns default email address when no valid primary email found