### PR TITLE
AIBUG-006: BUG - Concurrency race in Cache.getInstance

### DIFF
--- a/src/main/java/com/example/cache/Cache.java
+++ b/src/main/java/com/example/cache/Cache.java
@@ -35,9 +35,19 @@ public class Cache {
         });
     }
     
+    // BUG: Broken double-checked locking - race condition in singleton pattern
     public static Cache getInstance() {
         if (instance == null) {
-            instance = new Cache();
+            synchronized (Cache.class) {
+                // Missing second null check - can create multiple instances
+                instance = new Cache();
+                // Simulate some initialization work that makes race condition more likely
+                try {
+                    Thread.sleep(1);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            }
         }
         return instance;
     }


### PR DESCRIPTION
## Summary
- Introduced race condition in Cache.getInstance singleton pattern
- Implemented broken double-checked locking without second null check inside synchronized block
- Multiple threads can create multiple instances of singleton Cache

## Test plan
- Concurrent calls to getInstance() may result in multiple Cache instances being created
- Race condition occurs when multiple threads pass first null check simultaneously
- Breaks singleton pattern contract