### PR TITLE
AIBUG-006: FIX - Concurrency race in Cache.getInstance

### DIFF
--- a/src/main/java/com/example/cache/Cache.java
+++ b/src/main/java/com/example/cache/Cache.java
@@ -35,17 +35,19 @@ public class Cache {
         });
     }
     
-    // BUG: Broken double-checked locking - race condition in singleton pattern
+    // FIX: Proper double-checked locking pattern for thread-safe singleton
     public static Cache getInstance() {
         if (instance == null) {
             synchronized (Cache.class) {
-                // Missing second null check - can create multiple instances
-                instance = new Cache();
-                // Simulate some initialization work that makes race condition more likely
-                try {
-                    Thread.sleep(1);
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
+                // Second null check to prevent multiple instance creation
+                if (instance == null) {
+                    instance = new Cache();
+                    // Simulate some initialization work
+                    try {
+                        Thread.sleep(1);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Fixed race condition in Cache.getInstance singleton pattern  
- Added proper second null check inside synchronized block for correct double-checked locking
- Prevents multiple Cache instances from being created under concurrent access

## Test plan
- Concurrent calls to getInstance() now always return the same singleton instance
- Proper synchronization prevents race condition in singleton creation
- Maintains singleton pattern contract under multithreaded environment