### PR TITLE
AIBUG-008: BUG - Resource leak in AccountService.readTemplate

### DIFF
--- a/src/main/java/com/example/service/AccountService.java
+++ b/src/main/java/com/example/service/AccountService.java
@@ -95,8 +95,19 @@ public class AccountService {
         String line;
         while ((line = reader.readLine()) != null) {
             content.append(line).append("\n");
+            
+            // BUG: Resource leak - if exception occurs here, BufferedReader never closed
+            if (line.contains("ERROR")) {
+                throw new IOException("Template contains error marker: " + line);
+            }
+            
+            // Another potential exception path that prevents resource cleanup
+            if (content.length() > 10000) {
+                throw new IOException("Template file too large: " + content.length());
+            }
         }
-        reader.close();
+        
+        reader.close(); // This line may not be reached if exceptions occur above
         return content.toString();
     }
     


### PR DESCRIPTION
## Summary
- Introduced resource leak in AccountService.readTemplate method
- BufferedReader is not properly closed when IOException occurs during template processing
- Added multiple exception paths that can prevent resource cleanup

## Test plan
- When template contains ERROR marker, BufferedReader remains open
- When template file is too large, resource leak occurs
- File handles accumulate under repeated template processing failures