### PR TITLE
AIBUG-011: BUG - Performance O(n^2) in AccountService.findDuplicateAccounts

### DIFF
--- a/src/main/java/com/example/service/AccountService.java
+++ b/src/main/java/com/example/service/AccountService.java
@@ -75,14 +75,21 @@ public class AccountService {
     
     public List<Account> findDuplicateAccounts(List<Account> accounts) {
         List<Account> duplicates = new ArrayList<>();
-        Set<String> seen = new HashSet<>();
         
-        for (Account account : accounts) {
-            String key = account.getUser().getName();
-            if (seen.contains(key)) {
-                duplicates.add(account);
-            } else {
-                seen.add(key);
+        // BUG: O(n²) algorithm - nested loops instead of using HashSet
+        for (int i = 0; i < accounts.size(); i++) {
+            Account currentAccount = accounts.get(i);
+            String currentName = currentAccount.getUser().getName();
+            
+            // Inner loop checking all previous accounts - O(n²) complexity
+            for (int j = 0; j < i; j++) {
+                Account previousAccount = accounts.get(j);
+                String previousName = previousAccount.getUser().getName();
+                
+                if (currentName.equals(previousName)) {
+                    duplicates.add(currentAccount);
+                    break; // Found duplicate, no need to check further
+                }
             }
         }
         return duplicates;


### PR DESCRIPTION
## Summary
- Introduced performance regression in AccountService.findDuplicateAccounts method
- Replaced efficient O(n) HashSet-based approach with O(n²) nested loops
- For each account, method now searches through all previous accounts linearly
- Performance degrades significantly as account list size increases

## Test plan
- With 1,000 accounts, method performs ~500,000 comparisons instead of 1,000
- With 10,000 accounts, method performs ~50,000,000 comparisons instead of 10,000
- Execution time increases quadratically with input size